### PR TITLE
Add item_uuid to order detail reponse

### DIFF
--- a/Order--Detail.md
+++ b/Order--Detail.md
@@ -48,6 +48,7 @@ empty body
   line_items: [
     {
       uuid: <uuid>,
+      item_uuid: <uuid>,
       sku_uuid: <uuid>,
       sku_id: <string>,
       sku_name: <string>,


### PR DESCRIPTION
This will allow me to link to the specific item on the front end.
This is also the canon for all other responses that include order detail