### PR TITLE
minor range name changes to item

### DIFF
--- a/Product--ItemDetails.md
+++ b/Product--ItemDetails.md
@@ -17,9 +17,9 @@ Note: `inventory_list` is same as `sub_catalog`
 ```json
 {
   title: <string>,
-  map: { min: <num>, max: <num> },
-  msrp: { min: <num>, max: <num> },
-  price: { min: <num>, max: <num> },
+  map_range: { min: <num>, max: <num> },
+  msrp_range: { min: <num>, max: <num> },
+  cost_range: { min: <num>, max: <num> },
   item_id: <string>,
   images: [
     { url: <string>, height: <num>, width: <num> },


### PR DESCRIPTION
price is a generic and has no specific meaning in our system right now ('cost' is more specific).  Since those are not the value of the thing itself, the various fields need to be a "range" or it's misadvertisement.