### PR TITLE
initial official draft of thanos product import format

### DIFF
--- a/Product--ItemDetails.md
+++ b/Product--ItemDetails.md
@@ -27,6 +27,7 @@ Note: `inventory_list` is same as `sub_catalog`
   ],
   description: <string>,
   categories: [ {uuid: <string>, name: <string> }, {uuid: <string>, name: <string> }, ... ],
+  // todo-jan31: consider distributor?
   manufacturer: <string>,
   brand: <string>,
   origin_country: <string>,
@@ -34,6 +35,7 @@ Note: `inventory_list` is same as `sub_catalog`
   fba_certified: <bool>,
   marketplace_restrictions: <string>,
   warranty: <string>,
+  // todo-jan31: consider return_policy_category and standard policy types
   return_policy: <string>,
   last_updated: <date>,
   supplier: {
@@ -50,12 +52,17 @@ Note: `inventory_list` is same as `sub_catalog`
   skus: [
     {
       uuid: <string>,
-      title: <string>, // derived attribute name
+      sku_id: <string>,
+      // derived attribute name: "<distinguishing_att_values> | ... | <num_units>u | <condition>"
+      // todo-oct31: title should remove anything that is redundant across all skus
+      title: <string>, 
       // inventory_lists only returned for retailers
       inventory_lists: [ {uuid: <string>, name: <string> }, {uuid: <string>, name: <string> }, ... ],
       // catalogs only returned for suppliers
       catalogs: [ {uuid: <string>, name: <string> }, {uuid: <string>, name: <string> }, ... ],
       minimum_advertised_price: <num>,
+      // todo-jan31: use full word 'refurbished'
+      condition: (enum: new, used, refurb),
       msrp: <num>,
       price_scheme: {
         uuid: <uuid>,
@@ -90,15 +97,16 @@ Note: `inventory_list` is same as `sub_catalog`
           width: <num>,
         },
       },
-      product_codes: [ // SKU ID -- ENSURE THIS IS FIRST
-        { name: <string>, code: <string> },
-        { name: <string>, code: <string> },
-        { name: <string>, code: <string> },
+      product_codes: [
+        // todo-jan31: consider breaking out isbn into isbn10 and isbn13
+        { <name>: code <string> },
+        { <name>: code <string> },
+        { <name>: code <string> },
         ...
       ],
       distinquishing_attributes: [
-        { name: <string>, value: <string> },
-        { name: <string>, value: <string> },
+        { <name>: <value> },
+        { <name>: <value> },
         ...
       ],
     },

--- a/Product--thanos-import-format.md
+++ b/Product--thanos-import-format.md
@@ -29,7 +29,7 @@ the last line specifying the item level information will be used.
 
     custom_attribute.[N].name CharField(128)
     custom_attribute.[N].value CharField(256)
-    custom_attribute.[N].type one_of(str, int, float, bool)
+    custom_attribute.[N].type (one_of: str, int, float, bool)
 
     # duplicate urls across sku or item will reference the same ProductImage
     product_images_for_item (comma separated urls)
@@ -39,23 +39,26 @@ the last line specifying the item level information will be used.
 #######################
 
     sku_id CharField(256) [**REQUIRED**]
-    restrictions one_of('tmpunavail', 'discontd')
+    // todo-jan31: consider longer words
+    restrictions (one_of: 'tmpunavail', 'discontd')
+    // todo-jan31: consider refurbished instead of refurb
+    condition (one of: 'new', 'used', 'refurb')
     quantity_in_stock (int >= 0)
     quantity_on_backorder (int >= 0)
     number_of_units_bundled (int >= 1)
-    minimum_advertised_price float
-    msrp float
+    minimum_advertised_price (float)
+    msrp (float)
 
     # measurements
-    weight float (kg)
-    length float (meters)
-    width float (meters)
-    height float (meters)
+    weight (float [kg])
+    length (float [meters])
+    width (float [meters])
+    height (float [meters])
 
-    package_weight float (kg)
-    package_length float (meters)
-    package_width float (meters)
-    package_height float (meters)
+    package_weight (float [kg])
+    package_length (float [meters])
+    package_width (float [meters])
+    package_height (float [meters])
 
     # identifiers
     upca CharField(12)
@@ -65,11 +68,10 @@ the last line specifying the item level information will be used.
     asin CharField(10)
     mpn CharField(128)
 
-    refurbished (bool)
 
     distinguishing_attribute.[N].name CharField(128)
     distinguishing_attribute.[N].value CharField(256)
-    distinguishing_attribute.[N].type one_of(str, int, float, bool)
+    distinguishing_attribute.[N].type (one_of: str, int, float, bool)
 
     # This will generate a new price tier for the specified catalog
     pricing.[N].catalog <uuid>

--- a/Product--thanos-import-format.md
+++ b/Product--thanos-import-format.md
@@ -1,0 +1,89 @@
+The thanos product import specification file allows items (the item is the
+parent) and skus (the sku is the child with variant attributes) to be imported
+into thanos.  Each item may be associated with multiple skus.
+
+The format is flat, meaning that the item level information will be duplicated
+for each sku.  If item level information changes between its children skus,
+the last line specifying the item level information will be used.
+
+```
+[N] => an integer
+
+#######################
+# item level info
+#######################
+
+    item_id CharField(256) [**REQUIRED**]
+    title CharField(256) [**REQUIRED**]
+    description text (max 65,535 chars)
+    warranty text (max 65,535 chars)
+    return_policy (max 65,535 chars)
+    manufacturer CharField(128)
+    brand CharField(128)
+    country_of_origin (Valid 2 letter country code)
+    shipping_origin_country (Valid 2 letter country code)
+    categories (comma_separated uuids)
+    restrict_from_marketplaces comma_separated('amazon, 'ebay', 'newegg', 'overstock', 'walmart')
+    other_marketplace_restriction CharField(256)
+    fba_certified (bool)
+
+    custom_attribute.[N].name CharField(128)
+    custom_attribute.[N].value CharField(256)
+    custom_attribute.[N].type one_of(str, int, float, bool)
+
+    # duplicate urls across sku or item will reference the same ProductImage
+    product_images_for_item (comma separated urls)
+
+#######################
+# sku level info
+#######################
+
+    sku_id CharField(256) [**REQUIRED**]
+    restrictions one_of('tmpunavail', 'discontd')
+    quantity_in_stock (int >= 0)
+    quantity_on_backorder (int >= 0)
+    number_of_units_bundled (int >= 1)
+    minimum_advertised_price float
+    msrp float
+
+    # measurements
+    weight float (kg)
+    length float (meters)
+    width float (meters)
+    height float (meters)
+
+    package_weight float (kg)
+    package_length float (meters)
+    package_width float (meters)
+    package_height float (meters)
+
+    # identifiers
+    upca CharField(12)
+    ean13 CharField(13)
+    gtin14 CharField(14)
+    isbn CharField(13)
+    asin CharField(10)
+    mpn CharField(128)
+
+    refurbished (bool)
+
+    distinguishing_attribute.[N].name CharField(128)
+    distinguishing_attribute.[N].value CharField(256)
+    distinguishing_attribute.[N].type one_of(str, int, float, bool)
+
+    # This will generate a new price tier for the specified catalog
+    pricing.[N].catalog <uuid>
+    pricing.[N].minimum_tier_quantity (int)
+    pricing.[N].cost (float)
+    pricing.[N].shipping_cost (float)
+    pricing.[N].shipping_cost_is_estimate (bool)
+
+    # Or, an existing price scheme may be specified like this:
+    catalog--price_scheme (<catalogX-uuid>,<price_schemeX-uuid>;<catalogY-uuid>,<price_schemeY>;... [semi-colon separated comma separated pairs])
+
+    # duplicate urls across sku or item will reference the same ProductImage
+    product_images_for_sku (comma separated urls) [in future will support uuids]
+
+    catalogs (comma separated uuids) [**SUPPLIER-ONLY**]
+    inventory_lists (comma separated uuids--export only) [**RETAILER-ONLY**, **EXPORT-ONLY**]
+```


### PR DESCRIPTION
I'm asking for input/criticism from lots of reviewers since this will likely be used for other csv specifications.  This draft builds upon the format we successfully used for our team mtg presentation.

Most attributes are straightforward.  Three special cases are outlined below:

* Many items of the same type are designated by a comma separated list (e.g., categories is a comma separated list of uuids).  I prefer comma without a space, but that's negotiable (is comma with space better?).  _I've seen this convention in multiple other product definition files (channel advisor etc)._
* Nested objects are denoted with dot integer notation headers.  For instance, custom attributes would have the following headers: `custom_attribute.1.name`, `custom_attribute.1.value`, and `custom_attribute.1.type`.  The integer serves to properly group together (and potentially prioritize) the nested object.  _I've seen close variants of this in other json-to-csv formulations._
* Associations with existing objects may be specified with semicolon separated, comma separated 2-tuples.  The header is specified with a double-hyphen.  So the header `catalog--price_scheme` will have data that looks like this: `<catalogX-uuid>,<price_schemeX-uuid>;<catalogY-uuid>,<price_schemeY>;...`.  _I made this up after playing around with various ways of doing associations and it was the cleaner than anything else I could come up with._

The associations specification above is not _necessary_ for initial release, but it would be useful, and I think it is only a matter of time until we will need/want to allow associations between existing objects.
    