### PR TITLE
Search Catalog URL

### DIFF
--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -5,10 +5,10 @@
 ### URL
 
 Search Items:
-  GET /api/items/<item-uuid>
+  GET /api/items/<item-uuid>/
 
 Search Inventory List:
-  GET /api/product/<item-uuid>
+  GET /api/product/<item-uuid>/
 
 ### Request
 

--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -5,10 +5,10 @@
 ### URL
 
 Search Items:
-  GET /api/items/<item-uuid>/
+  GET /api/products/items/
 
 Search Inventory List:
-  GET /api/product/<item-uuid>/
+  GET /api/products/inventory-lists/<uuid>/
 
 ### Request
 

--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -5,10 +5,10 @@
 ### URL
 
 Search Items:
-  GET /api/products/items/search/
+  POST /api/products/items/search/
 
 Search Inventory List:
-  GET /api/products/inventory-lists/<uuid>/search/
+  POST /api/products/inventory-lists/<uuid>/search/
 
 ### Request
 

--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -5,10 +5,10 @@
 ### URL
 
 Search Items:
-  GET /api/products/items/
+  GET /api/products/items/search/
 
 Search Inventory List:
-  GET /api/products/inventory-lists/<uuid>/
+  GET /api/products/inventory-lists/<uuid>/search/
 
 ### Request
 

--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -7,7 +7,11 @@
 
 ###
 
-??????????
+Search Items:
+  GET /api/items/<item-uuid>
+
+Search Inventory List:
+  GET /api/product/<item-uuid>
 
 ### Request
 
@@ -48,6 +52,7 @@
         max: <num>,
       },
       sku_count: <num>,
+      included_sku_count: <num>,  // Only for Inventory
       last_updated: <date>,
     },
     ...

--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -1,11 +1,8 @@
 ### Changes to discuss:
 
-1. URL
 2. list\_id filter item
 
 ### URL
-
-###
 
 Search Items:
   GET /api/items/<item-uuid>


### PR DESCRIPTION
Documents the URL for: 
- Search Items:   POST /api/products/items/search/
- Search Inventory List:    POST /api/products/items/{uuid}/search/

Adds for Inventory List only, a count of included skus for an item (included_sku_count: <num>).  

The current sku_count property tracks the total number of sku variants for an item.  A user may choose to only include a partial set of item skus in a list.  The inventory list UI will display both both the total and included variants..