### PR TITLE
Standardize item title

### DIFF
--- a/Product--SearchCatalog-SubCatalog_and_Inventory.md
+++ b/Product--SearchCatalog-SubCatalog_and_Inventory.md
@@ -49,7 +49,7 @@ a filter (if uuids) or facets (if using a name).
     {
       uuid: <string>,
       item_id: <string>,
-      name: <string>,
+      title: <string>,
       image: <url>,
       supplier: {
         uuid: <string>,


### PR DESCRIPTION
Standardize Product Item Title

Updates Product--SearchCatalog-SubCatalog_and_Inventory response to use item.title (instead of item.name).  This standardizes the naming convention with ItemsDetail