### PR TITLE
remove price-scheme / catalog association

### DIFF
--- a/Product--thanos-import-format.md
+++ b/Product--thanos-import-format.md
@@ -80,9 +80,6 @@ the last line specifying the item level information will be used.
     pricing.[N].shipping_cost (float)
     pricing.[N].shipping_cost_is_estimate (bool)
 
-    # Or, an existing price scheme may be specified like this:
-    catalog--price_scheme (<catalogX-uuid>,<price_schemeX-uuid>;<catalogY-uuid>,<price_schemeY>;... [semi-colon separated comma separated pairs])
-
     # duplicate urls across sku or item will reference the same ProductImage
     product_images_for_sku (comma separated urls) [in future will support uuids]
 


### PR DESCRIPTION
Price schemes no longer can be referred to by uuid, so this association makes no sense anymore.  Price schemes must be specified with all price tier information.

(If no price tier fields are present then existing price data will remain intact.  If _any_ price tier fields are present then full pricing information must be specified).