### PR TITLE
add supplier uuid to order create to find sku

### DIFF
--- a/Order--Create.md
+++ b/Order--Create.md
@@ -6,7 +6,7 @@ POST /api/order/create/
 
 ### Request
 
-(Required fields: `skus`, `address`, `shipping_carrier`, `shipping_method`, `purchase_order_id`)
+(Required fields: `skus`, `address`, `shipping_carrier`, `shipping_method`, `purchase_order_id`, `supplier_uuid`)
 (Optional fields: `notes`, `address.business_name`, `address.address2` )
 
 ```js

--- a/Order--Create.md
+++ b/Order--Create.md
@@ -31,6 +31,7 @@ POST /api/order/create/
   shipping_method: <string>,
   purchase_order_id: <string>,
   notes: <string>,
+  supplier_uuid: <uuid>,
 }
 ```
 


### PR DESCRIPTION
Since the sku id being passed in could potentially be duplicated, I need the supplier uuid as identifier to be able to narrow down the sku belonging to the appropriate supplier.  