### PR TITLE
measurements/categories changes to thanos product import/export

### DIFF
--- a/Product--thanos-import-format.md
+++ b/Product--thanos-import-format.md
@@ -22,7 +22,7 @@ the last line specifying the item level information will be used.
     brand CharField(128)
     country_of_origin (Valid 2 letter country code)
     shipping_origin_country (Valid 2 letter country code)
-    categories (comma_separated uuids)
+    categories ('>' category path separator, '|' category separator, eg. Home > Craft > Sewing | Outdoors > Hiking)
     restrict_from_marketplaces comma_separated('amazon, 'ebay', 'newegg', 'overstock', 'walmart')
     other_marketplace_restriction CharField(256)
     fba_certified (bool)
@@ -50,15 +50,19 @@ the last line specifying the item level information will be used.
     msrp (float)
 
     # measurements
-    weight (float [kg])
-    length (float [meters])
-    width (float [meters])
-    height (float [meters])
+    sku_weight (float)
+    sku_weight_units (one_of: 'g', 'kg', 'lb', 'oz'; defaults to g; must specify to save as preferred units)
+    sku_length (float)
+    sku_width (float)
+    sku_height (float)
+    sku_dimension_units (one_of: 'cm', 'm', 'in', 'ft'; defaults to cm; must specify to save as preferred units)
 
-    package_weight (float [kg])
-    package_length (float [meters])
-    package_width (float [meters])
-    package_height (float [meters])
+    package_weight (float)
+    package_weight_units (one_of: 'g', 'kg', 'lb', 'oz'; defaults to g; must specify to save as preferred units)
+    package_length (float)
+    package_width (float)
+    package_height (float)
+    package_dimension_units (one_of: 'cm', 'm', 'in', 'ft'; defaults to cm; must specify to save as preferred units)
 
     # identifiers
     upca CharField(12)


### PR DESCRIPTION
Suppliers need to be able to specify categories in some kind of category specification, and we want suppliers to be able to give and receive measurements with whatever units they prefer.

@konan - I'm still finishing up the implementation, but the changes to the graph file can be started so we get to the finish line at the same time.

Anyone who cares about our CSV interface will also want to check this out, so potentially @jfischerlaunch , @ShaggyD , @edje-jeter, @Gidgidonihah and @nickcoleman.